### PR TITLE
This adds the insertion/query functions of ORB-BoW Database

### DIFF
--- a/include/PlaceRecognizer.hpp
+++ b/include/PlaceRecognizer.hpp
@@ -31,6 +31,7 @@ private:
     ros::Publisher output_pub_;
     cv_bridge::CvImagePtr image_ptr_;
     cv_bridge::CvImagePtr output_ptr_;
+    cv::Mat output_descriptors_;
 
     boost::shared_ptr<ORBVocabulary> vocabulary_ptr_;
     boost::shared_ptr<ORBDatabase> database_ptr_;

--- a/include/PlaceRecognizer.hpp
+++ b/include/PlaceRecognizer.hpp
@@ -31,7 +31,7 @@ private:
     ros::Publisher output_pub_;
     cv_bridge::CvImagePtr image_ptr_;
     cv_bridge::CvImagePtr output_ptr_;
-    cv::Mat output_descriptors_;
+    std::vector< cv::Mat > output_descriptors_;
 
     boost::shared_ptr<ORBVocabulary> vocabulary_ptr_;
     boost::shared_ptr<ORBDatabase> database_ptr_;
@@ -47,6 +47,8 @@ public:
     bool loadVocabulary (const std::string& voc_filename = "ORBvoc.txt");
     bool loadDatabase (const std::string& db_filename = "ORBdb.yml");
     bool saveDatabase (const std::string& db_filename = "ORBdb.yml");
+
+    void transform_store_descriptors (const cv::Mat& mat);
 
 };
 

--- a/include/place_recognition.hpp
+++ b/include/place_recognition.hpp
@@ -4,6 +4,6 @@
 #include <string>
 #include <ros/ros.h>
 
-const char* VERSION_STRING = "0.1.1";
+const char* VERSION_STRING = "0.1.2";
 
 #endif

--- a/src/PlaceRecognizer.cpp
+++ b/src/PlaceRecognizer.cpp
@@ -18,6 +18,7 @@
 
 #include "PlaceRecognizer.hpp"
 #include <string.h>
+#include <iostream>
 
 using namespace place_recognizer;
 
@@ -45,7 +46,7 @@ PlaceRecognizer::PlaceRecognizer() {
 
     // Initialize ORB Feature Detector and Extractors
     detector_ptr_ = cv::Ptr<cv::FeatureDetector> (new cv::ORB(1000));
-
+    extractor_ptr_ = cv::Ptr<cv::DescriptorExtractor> (new cv::ORB(1000));
 
     ROS_INFO ("Place Recognizer Setup OK");
 }
@@ -56,6 +57,9 @@ PlaceRecognizer::~PlaceRecognizer() {}
 void PlaceRecognizer::trigger_callback (const std_msgs::String &msg) {
     //TODO: Implement DB Updating and Tagging
     ROS_INFO ("DB Insertion TRIGGERED");
+    ROS_DEBUG ("cv::Mat output_descriptors_ size: <%d, %d>", output_descriptors_.rows, output_descriptors_.cols);
+    DBoW2::EntryId entryID = database_ptr_->add (output_descriptors_);
+    ROS_INFO ("DB Inserted EntryID: %u", entryID);
 }
 
 // Callback for Image Messages
@@ -70,14 +74,28 @@ void PlaceRecognizer::image_callback (const sensor_msgs::ImageConstPtr &msg) {
         ROS_ERROR ("cv_bridge exception: %s", e.what());
     }
 
-    // Identify and Extract Features using ORB
+    /** Identify and Extract Features using ORB
+      *
+    **/
     std::vector<cv::KeyPoint> keypoints;
     detector_ptr_->detect (image_ptr_->image, keypoints);
     ROS_DEBUG ("Detected %lu keypoints", keypoints.size());
     // Draw Keypoints over output_ptr_
     cv::drawKeypoints (image_ptr_->image, keypoints, output_ptr_->image, cv::DrawMatchesFlags::DEFAULT);
+    // Extract Descriptors from Keypoints
+    ROS_DEBUG ("Extracting KeyPoints");
+    extractor_ptr_->compute (image_ptr_->image, keypoints, output_descriptors_);
+    ROS_DEBUG ("computed cv::Mat output_descriptors_ size: <%d, %d>", output_descriptors_.rows, output_descriptors_.cols);
 
     // TODO: Perform Database Query for matching images
+    if (database_ptr_->size() > 0) {
+        ROS_DEBUG ("DB - Querying");
+        static DBoW2::QueryResults results;
+        database_ptr_->query (output_descriptors_, results, 3);
+        ROS_DEBUG ("DB - Parsing Results");
+        DBoW2::Result top_result = *(results.begin());
+        ROS_INFO ("Top Result: Image %u - Score: %f", top_result.Id, top_result.Score);
+    }
 
     // Publish the augmented image
     output_pub_.publish (output_ptr_->toImageMsg());
@@ -117,7 +135,7 @@ bool PlaceRecognizer::loadDatabase (const std::string& db_filename) {
         ROS_DEBUG ("Database - Loading - file: %s", db_filename.c_str());
         database_ptr_ = boost::shared_ptr<ORBDatabase> (new ORBDatabase (db_filename));
         fail = false;
-        ROS_DEBUG ("Database - Load SUCCESS");
+        ROS_INFO ("Database - Load SUCCESS");
     } catch (std::string &exception_msg) {
         ROS_WARN ("Database - Load FAIL - file: %s : %s", db_filename.c_str(), exception_msg.c_str());
     } catch (cv::Exception &exception) {
@@ -129,7 +147,7 @@ bool PlaceRecognizer::loadDatabase (const std::string& db_filename) {
         loadVocabulary();
         database_ptr_ = boost::shared_ptr<ORBDatabase> (new ORBDatabase (*vocabulary_ptr_, false, 0));
         fail = false;
-        ROS_DEBUG ("Database - Create SUCCESS");
+        ROS_INFO ("Database - Create SUCCESS");
     }
 
     return !fail;

--- a/src/PlaceRecognizer.cpp
+++ b/src/PlaceRecognizer.cpp
@@ -47,6 +47,7 @@ PlaceRecognizer::PlaceRecognizer() {
     // Initialize ORB Feature Detector and Extractors
     detector_ptr_ = cv::Ptr<cv::FeatureDetector> (new cv::ORB(1000));
     extractor_ptr_ = cv::Ptr<cv::DescriptorExtractor> (new cv::ORB(1000));
+    output_descriptors_ = std::vector<cv::Mat>();
 
     ROS_INFO ("Place Recognizer Setup OK");
 }
@@ -189,9 +190,9 @@ void PlaceRecognizer::transform_store_descriptors (const cv::Mat& mat) {
     if (mat.type() == 0) {
         ROS_DEBUG ("Transform - U8C1 cv::Mat to vector<cv::Mat>");
         ROS_DEBUG ("cv::Mat descriptors type: %i size: <%d, %d>", mat.type(), mat.rows, mat.cols);
-        output_descriptors_ = std::vector< cv::Mat > (mat.cols);
-        for (int col = 0; col < mat.cols; col++) {
-            cv::Rect regionOfInterest (col, 0, 1, mat.rows);
+        output_descriptors_.clear();
+        for (int row = 0; row < mat.rows; row++) {
+            cv::Rect regionOfInterest (0, row, mat.cols, 1);
             output_descriptors_.push_back (cv::Mat (mat, regionOfInterest));
         }
         ROS_DEBUG ("Transform - SUCCESS");

--- a/src/PlaceRecognizer.cpp
+++ b/src/PlaceRecognizer.cpp
@@ -57,8 +57,11 @@ PlaceRecognizer::~PlaceRecognizer() {}
 void PlaceRecognizer::trigger_callback (const std_msgs::String &msg) {
     //TODO: Implement DB Updating and Tagging
     ROS_INFO ("DB Insertion TRIGGERED");
-    DBoW2::EntryId entryID = database_ptr_->add (output_descriptors_);
-    ROS_INFO ("DB Inserted EntryID: %u", entryID);
+    //DBoW2::EntryId entryID = database_ptr_->add (output_descriptors_);
+    DBoW2::BowVector vec;
+    database_ptr_->getVocabulary()->transform (output_descriptors_, vec);
+    ROS_INFO ("DB - Conversion to BoW Vector - OK");
+    //ROS_INFO ("DB Inserted EntryID: %u", entryID);
 }
 
 // Callback for Image Messages

--- a/src/PlaceRecognizer.cpp
+++ b/src/PlaceRecognizer.cpp
@@ -60,7 +60,8 @@ void PlaceRecognizer::trigger_callback (const std_msgs::String &msg) {
     ROS_INFO ("DB Insertion TRIGGERED");
     //DBoW2::EntryId entryID = database_ptr_->add (output_descriptors_);
     DBoW2::BowVector vec;
-    database_ptr_->getVocabulary()->transform (output_descriptors_, vec);
+    // database_ptr_->getVocabulary()->transform (output_descriptors_, vec);
+    database_ptr_->add (output_descriptors_);
     ROS_INFO ("DB - Conversion to BoW Vector - OK");
     //ROS_INFO ("DB Inserted EntryID: %u", entryID);
 }


### PR DESCRIPTION
Prior to this, master branch suffered a crash whenever DB insert/query operations occurred.
This was due to a segfault in 'DBoW2::FORB::distance(cv::Mat&, cv::Mat&)' caused by:
- not initializing / clearing the `std::vector<cv::Mat> output_descriptors_`
- selecting the wrong region of interest (i.e. should iterate `mat.rows` and select ROI using range 0 to `mat.cols` to get rows, instead of iterating `mat.rows` and vice versa)